### PR TITLE
Rename placement group strategy

### DIFF
--- a/cases/aws_instance/main.tf
+++ b/cases/aws_instance/main.tf
@@ -11,7 +11,7 @@ resource "aws_key_pair" "test_key_pair" {
 
 resource "aws_placement_group" "test_placement_group" {
   name     = "test_placement_group"
-  strategy = "distribute"
+  strategy = "spread"
 }
 
 resource "aws_instance" "test_instance" {

--- a/cases/aws_placement_group/README.rst
+++ b/cases/aws_placement_group/README.rst
@@ -11,7 +11,7 @@ Differences
 Notes
 ~~~~~
 
-The only supported value for ``strategy`` attribute is ``distribute``.
+The only supported value for ``strategy`` attribute is ``spread``.
 
 Example
 -------

--- a/cases/aws_placement_group/main.tf
+++ b/cases/aws_placement_group/main.tf
@@ -1,6 +1,6 @@
 resource "aws_placement_group" "test_placement_group" {
   name = "test_placement_group"
 
-  # NOTE: the only supported value for 'strategy' attribute is 'distribute'
+  # NOTE: the only supported value for 'strategy' attribute is 'spread'
   strategy = "spread"
 }

--- a/cases/aws_placement_group/main.tf
+++ b/cases/aws_placement_group/main.tf
@@ -2,5 +2,5 @@ resource "aws_placement_group" "test_placement_group" {
   name = "test_placement_group"
 
   # NOTE: the only supported value for 'strategy' attribute is 'distribute'
-  strategy = "distribute"
+  strategy = "spread"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- rename ```distribute``` -> ```spread``` strategy due to latest croc cloud [release](http://docs.website.cloud.croc.ru/en/api/ec2/placements/CreatePlacementGroup.html)

**Which issue(s) this PR fixes**:
- None

**Special notes for your reviewer**:
- None 