### PR TITLE
Generate ssh-key in cases

### DIFF
--- a/cases/aws_instance/main.tf
+++ b/cases/aws_instance/main.tf
@@ -1,3 +1,7 @@
+resource "tls_private_key" "ssh" {
+  algorithm   = "RSA"
+}
+
 resource "aws_security_group" "additional_security_group" {
   name        = "additional_security_group"
   description = "additional_security_group"
@@ -6,7 +10,7 @@ resource "aws_security_group" "additional_security_group" {
 
 resource "aws_key_pair" "test_key_pair" {
   key_name   = "terraform_key"
-  public_key = "${var.material}"
+  public_key = "${tls_private_key.ssh.public_key_openssh}"
 }
 
 resource "aws_placement_group" "test_placement_group" {

--- a/cases/aws_key_pair/main.tf
+++ b/cases/aws_key_pair/main.tf
@@ -1,9 +1,13 @@
+resource "tls_private_key" "ssh" {
+  algorithm   = "RSA"
+}
+
 resource "aws_key_pair" "test_key_pair_with_name_prefix" {
   key_name_prefix = "terraform"
-  public_key      = "${var.material}"
+  public_key      = "${tls_private_key.ssh.public_key_openssh}"
 }
 
 resource "aws_key_pair" "test_key_pair" {
   key_name   = "test_key_pair"
-  public_key = "${var.material}"
+  public_key = "${tls_private_key.ssh.public_key_openssh}"
 }

--- a/common/subnet.tf
+++ b/common/subnet.tf
@@ -1,4 +1,5 @@
 resource "aws_subnet" "test_subnet" {
+  availability_zone = "${var.az}"
   vpc_id = "${aws_vpc.test_vpc.id}"
 
   cidr_block = "${cidrsubnet(aws_vpc.test_vpc.cidr_block, 1, 0)}"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,3 @@
-variable "material" {}
 variable "ec2_url" {}
 variable "s3_url" {}
 variable "access_key" {}
@@ -20,6 +19,8 @@ variable "account_id" {}
 variable "insecure" {
   default = false
 }
+
+provider "tls" {}
 
 provider "aws" {
   endpoints {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -14,5 +14,3 @@ account_id = "<your_access_key>"
 instance_type = "<desired_instance_type>"
 
 ami = "<desired_ami_id>"
-
-material = "<your_public_ssh_key>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Configuration can be simplified if we remove dependency for public ssh-key in cases.

**Which issue(s) this PR fixes**:
#17 

**Special notes for your reviewer**:
