### PR TITLE
Add timeouts to long running operations

### DIFF
--- a/cases/aws_ami/main.tf
+++ b/cases/aws_ami/main.tf
@@ -36,4 +36,10 @@ resource "aws_ami" "test_ami_from_snapshot" {
 
     snapshot_id = "${aws_ebs_snapshot.test_snapshot.id}"
   }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }

--- a/cases/aws_ami_from_instance/main.tf
+++ b/cases/aws_ami_from_instance/main.tf
@@ -12,4 +12,10 @@ resource "aws_ami_from_instance" "test_ami" {
   name = "test_ami"
 
   source_instance_id = "${aws_instance.test_instance.id}"
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }

--- a/cases/aws_ami_launch_permission/main.tf
+++ b/cases/aws_ami_launch_permission/main.tf
@@ -20,6 +20,12 @@ resource "aws_ami" "test_ami" {
     device_name = "disk1"
     snapshot_id = "${aws_ebs_snapshot.test_snapshot.id}"
   }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "aws_ami_launch_permission" "test_ami_launch" {

--- a/cases/aws_instance/run_instance_with_cdrom/main.tf
+++ b/cases/aws_instance/run_instance_with_cdrom/main.tf
@@ -18,6 +18,12 @@ resource "aws_ami" "test_ami_with_cdrom" {
     volume_type = "st2"
     volume_size = 32
   }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "aws_instance" "test_instance_with_cdrom" {

--- a/cases/aws_instance/run_instances_remove_cdrom/main.tf
+++ b/cases/aws_instance/run_instances_remove_cdrom/main.tf
@@ -18,6 +18,12 @@ resource "aws_ami" "test_ami" {
     volume_type = "st2"
     volume_size = 32
   }
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
 }
 
 resource "aws_instance" "test_instance" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Default terraform time-outs are equal to 40m.
This pr reduces timeouts to 10m, for future ci intergation.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
