### PR TITLE
aws_security_group_rule: add new supported attribute

### DIFF
--- a/cases/aws_security_group_rule/README.rst
+++ b/cases/aws_security_group_rule/README.rst
@@ -12,7 +12,6 @@ Unsupported attributes
 ~~~~~~~~~~~~~~~~~~~~~~
 
 * ``prefix_list_ids``
-* ``description``
 
 Example
 -------

--- a/cases/aws_security_group_rule/main.tf
+++ b/cases/aws_security_group_rule/main.tf
@@ -4,10 +4,11 @@ resource "aws_security_group" "source_security_group" {
 }
 
 resource "aws_security_group_rule" "allow_udp" {
-  # NOTE: 'prefix_list_ids ', 'description' attributes are not supported
+  # NOTE: 'prefix_list_ids ' attributes are not supported
   type                     = "ingress"
   from_port                = 11
   to_port                  = 33
+  description              = "some_description"
   protocol                 = "udp"
   source_security_group_id = "${aws_security_group.source_security_group.id}"
   security_group_id        = "${aws_security_group.test_security_group.id}"


### PR DESCRIPTION
**What this PR does / why we need it**:
croc cloud 15.4 add support for ```description``` attribute in ```aws_security_group_rule``` resource 
**Which issue(s) this PR fixes**:
#24 
**Special notes for your reviewer**:
