### PR TITLE
[cases aws_instance] remove unsupported attribute

### DIFF
--- a/cases/aws_instance/README.rst
+++ b/cases/aws_instance/README.rst
@@ -31,6 +31,7 @@ Unsupported attributes
 * ``volume_tags``
 * ``network_interface``
 * ``credit_specification``
+* ``private_ip``
 
 Example
 -------

--- a/cases/aws_instance/main.tf
+++ b/cases/aws_instance/main.tf
@@ -22,7 +22,7 @@ resource "aws_instance" "test_instance" {
   # NOTE: 'tenancy', 'host_id', 'cpu_core_count', 'cpu_threat_per_code',
   #       'ebs_optimized', 'get_password_data', 'monitoring', 'iam_instance_profile',
   #       'ipv6_address_count', 'ipv6_addresses', 'volume_tags', 'network_interface',
-  #       'credit_specification' attributes are not supported.
+  #       'credit_specification', 'private_ip' attributes are not supported.
   ami = "${var.ami}"
 
   availability_zone                    = "${var.az}"
@@ -35,7 +35,6 @@ resource "aws_instance" "test_instance" {
   monitoring                           = true
   vpc_security_group_ids               = ["${aws_security_group.test_security_group.id}", "${aws_security_group.additional_security_group.id}"]
   subnet_id                            = "${aws_subnet.test_subnet.id}"
-  private_ip                           = "${cidrhost(aws_subnet.test_subnet.cidr_block, 3)}"
   source_dest_check                    = true
   user_data                            = "echo hello"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unsupported private_ip attr in aws_instance resource

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
