### PR TITLE
[cases aws_eip] update example with new supported attribute

### DIFF
--- a/cases/aws_eip/README.rst
+++ b/cases/aws_eip/README.rst
@@ -11,7 +11,6 @@ Differences
 Unsupported attributes
 ~~~~~~~~~~~~~~~~~~~~~~
 
-* ``public_ipv4_pull``
 * ``associate_with_private_ip``
 
 Example

--- a/cases/aws_eip/main.tf
+++ b/cases/aws_eip/main.tf
@@ -18,4 +18,5 @@ resource "aws_network_interface" "test1" {
 resource "aws_eip" "test2" {
   vpc = true
   network_interface = "${aws_network_interface.test1.id}"
+  public_ipv4_pool = "${var.public_ipv4_pool}"
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ variable "s3_url" {}
 variable "access_key" {}
 variable "secret_key" {}
 variable "ami" {}
+variable "public_ipv4_pool" {}
 
 variable "region" {
   default = "croc"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -14,3 +14,5 @@ account_id = "<your_access_key>"
 instance_type = "<desired_instance_type>"
 
 ami = "<desired_ami_id>"
+
+public_ipv4_pool = "<public_pool>"


### PR DESCRIPTION
**What this PR does / why we need it**:
16.5.1 CROC Cloud release brings suppor for ``addresses public pools``.
This pr adds configuration example with ``public_ipv4_pool`` in ``aws_eip`` resource.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
