### PR TITLE
Skip aws_default_vpc_dhcp_options tests

### DIFF
--- a/tests/aws_default_vpc_dhcp_options.at
+++ b/tests/aws_default_vpc_dhcp_options.at
@@ -1,10 +1,11 @@
-AT_BANNER([plan,apply,destroy,import aws_default_vpc_dhcp_options resource])
+AT_BANNER([plan aws_default_vpc_dhcp_options resource; most of tests are skipped due to c2 bugs])
 
 AT_SETUP([plan aws_default_vpc_dhcp_options])
 AT_CHECK([cd "$SRCDIR" && make plan-aws_default_vpc_dhcp_options],,[ignore],[ignore])
 AT_CLEANUP
 
 AT_SETUP([apply aws_default_vpc_dhcp_options])
+AT_SKIP_IF([true])
 AT_CHECK([cd "$SRCDIR" && make apply-aws_default_vpc_dhcp_options],,[ignore],[ignore])
 AT_CLEANUP
 
@@ -14,6 +15,7 @@ AT_CHECK([cd "$SRCDIR" && make apply-data_aws_default_vpc_dhcp_options],,[ignore
 AT_CLEANUP
 
 AT_SETUP([destroy aws_default_vpc_dhcp_options])
+AT_SKIP_IF([true])
 AT_CHECK([cd "$SRCDIR" && make destroy-aws_default_vpc_dhcp_options],,[ignore],[ignore])
 AT_CLEANUP
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip aws_default_vpc_dhcp_options due to c2 bugs. currently default vpc doesn't have default dhcp settings attached to it.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
