### PR TITLE
aws_instance: INIS, default subnets and private_ip support

### DIFF
--- a/cases/aws_eip/main.tf
+++ b/cases/aws_eip/main.tf
@@ -5,7 +5,6 @@ resource "aws_instance" "test1" {
 }
 
 resource "aws_eip" "test1" {
-  # NOTE: 'public_ipv4_pull' is not supported.
   instance = aws_instance.test1.id
 
   vpc = true

--- a/cases/aws_instance/README.rst
+++ b/cases/aws_instance/README.rst
@@ -33,7 +33,6 @@ Unsupported attributes
 * ``volume_tags``
 * ``network_interface``
 * ``credit_specification``
-* ``private_ip``
 
 Special notes
 -------------

--- a/cases/aws_instance/README.rst
+++ b/cases/aws_instance/README.rst
@@ -11,6 +11,7 @@ This example introduces ``aws_instance`` resource.
    run_instance_with_cdrom/README
    run_instance_with_ebs_override/README
    run_instance_with_data_source_ami/README
+   run_instance_with_existing_network_interface/README
    run_instance_default_subnet/README
    run_instances_remove_cdrom/README
 
@@ -31,7 +32,6 @@ Unsupported attributes
 * ``ipv6_address_count``
 * ``ipv6_addresses``
 * ``volume_tags``
-* ``network_interface``
 * ``credit_specification``
 
 Special notes

--- a/cases/aws_instance/README.rst
+++ b/cases/aws_instance/README.rst
@@ -11,6 +11,7 @@ This example introduces ``aws_instance`` resource.
    run_instance_with_cdrom/README
    run_instance_with_ebs_override/README
    run_instance_with_data_source_ami/README
+   run_instance_default_subnet/README
    run_instances_remove_cdrom/README
 
 Differences

--- a/cases/aws_instance/main.tf
+++ b/cases/aws_instance/main.tf
@@ -22,7 +22,7 @@ resource "aws_instance" "test_instance" {
   # NOTE: 'tenancy', 'host_id', 'cpu_core_count', 'cpu_threat_per_code',
   #       'ebs_optimized', 'get_password_data', 'monitoring', 'iam_instance_profile',
   #       'ipv6_address_count', 'ipv6_addresses', 'network_interface',
-  #       'credit_specification', 'private_ip' attributes are not supported.
+  #       'credit_specification' attributes are not supported.
   ami = var.ami
 
   availability_zone                    = var.az
@@ -35,6 +35,7 @@ resource "aws_instance" "test_instance" {
   monitoring                           = true
   vpc_security_group_ids               = [aws_security_group.test_security_group.id, aws_security_group.additional_security_group.id]
   subnet_id                            = aws_subnet.test_subnet.id
+  private_ip                           = cidrhost(aws_subnet.test_subnet.cidr_block, 10)
   source_dest_check                    = true
   user_data                            = "echo hello"
 }

--- a/cases/aws_instance/main.tf
+++ b/cases/aws_instance/main.tf
@@ -21,8 +21,8 @@ resource "aws_placement_group" "test_placement_group" {
 resource "aws_instance" "test_instance" {
   # NOTE: 'tenancy', 'host_id', 'cpu_core_count', 'cpu_threat_per_code',
   #       'ebs_optimized', 'get_password_data', 'monitoring', 'iam_instance_profile',
-  #       'ipv6_address_count', 'ipv6_addresses', 'network_interface',
-  #       'credit_specification' attributes are not supported.
+  #       'ipv6_address_count', 'ipv6_addresses', 'credit_specification'
+  #       attributes are not supported.
   ami = var.ami
 
   availability_zone                    = var.az

--- a/cases/aws_instance/run_instance_default_subnet/README.rst
+++ b/cases/aws_instance/run_instance_default_subnet/README.rst
@@ -1,0 +1,10 @@
+run_instance_default_subnet
+===========================
+
+Summary
+-------
+This example introduces ``aws_instance`` resource with default subnet.
+
+Example
+-------
+.. literalinclude:: main.tf

--- a/cases/aws_instance/run_instance_default_subnet/main.tf
+++ b/cases/aws_instance/run_instance_default_subnet/main.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "test_instance_default_subnet" {
+  ami           = var.ami
+  instance_type = var.instance_type
+}

--- a/cases/aws_instance/run_instance_with_data_source_ami/main.tf
+++ b/cases/aws_instance/run_instance_with_data_source_ami/main.tf
@@ -12,8 +12,8 @@ data "aws_ami" "test_data_ami" {
 resource "aws_instance" "test_instance" {
   # NOTE: 'tenancy', 'host_id', 'cpu_core_count', 'cpu_threat_per_code',
   #       'ebs_optimized', 'get_password_data', 'monitoring', 'iam_instance_profile',
-  #       'ipv6_address_count', 'ipv6_addresses', 'network_interface',
-  #       'credit_specification' attributes are not supported.
+  #       'ipv6_address_count', 'ipv6_addresses', 'credit_specification'
+  #       attributes are not supported.
 
   ami                                  = data.aws_ami.test_data_ami.id
   availability_zone                    = var.az

--- a/cases/aws_instance/run_instance_with_data_source_ami/main.tf
+++ b/cases/aws_instance/run_instance_with_data_source_ami/main.tf
@@ -13,11 +13,12 @@ resource "aws_instance" "test_instance" {
   # NOTE: 'tenancy', 'host_id', 'cpu_core_count', 'cpu_threat_per_code',
   #       'ebs_optimized', 'get_password_data', 'monitoring', 'iam_instance_profile',
   #       'ipv6_address_count', 'ipv6_addresses', 'network_interface',
-  #       'credit_specification', 'private_ip' attributes are not supported.
+  #       'credit_specification' attributes are not supported.
 
   ami                                  = data.aws_ami.test_data_ami.id
   availability_zone                    = var.az
   instance_type                        = var.instance_type
   vpc_security_group_ids               = [ aws_security_group.test_security_group.id ]
   subnet_id                            = aws_subnet.test_subnet.id
+  private_ip                           = cidrhost(aws_subnet.test_subnet.cidr_block, 10)
 }

--- a/cases/aws_instance/run_instance_with_existing_network_interface/README.rst
+++ b/cases/aws_instance/run_instance_with_existing_network_interface/README.rst
@@ -1,0 +1,10 @@
+run_instance_with_existing_network_interface
+============================================
+
+Summary
+-------
+This example introduces ``aws_instance`` resource with existing network interface.
+
+Example
+-------
+.. literalinclude:: main.tf

--- a/cases/aws_instance/run_instance_with_existing_network_interface/main.tf
+++ b/cases/aws_instance/run_instance_with_existing_network_interface/main.tf
@@ -1,0 +1,12 @@
+resource "aws_network_interface" "test_interface" {
+  subnet_id = aws_subnet.test_subnet.id
+}
+
+resource "aws_instance" "test_instance_with_existing_network_interface" {
+  ami = var.ami
+  instance_type = var.instance_type
+  network_interface {
+    network_interface_id = aws_network_interface.test_interface.id
+    device_index         = 0
+  }
+}

--- a/cases/aws_instance/run_instance_with_existing_network_interface/subnet.tf
+++ b/cases/aws_instance/run_instance_with_existing_network_interface/subnet.tf
@@ -1,0 +1,1 @@
+../../../common/subnet.tf

--- a/cases/aws_instance/run_instance_with_existing_network_interface/vpc.tf
+++ b/cases/aws_instance/run_instance_with_existing_network_interface/vpc.tf
@@ -1,0 +1,1 @@
+../../../common/vpc.tf

--- a/tests/aws_instance.at
+++ b/tests/aws_instance.at
@@ -45,6 +45,14 @@ AT_SETUP([destroy run_instance_with_ebs_override])
 AT_CHECK([make -C "$SRCDIR" destroy-run_instance_with_ebs_override],,[ignore],[ignore])
 AT_CLEANUP
 
+AT_SETUP([apply run_instance_with_existing_network_interface])
+AT_CHECK([make -C "$SRCDIR" apply-run_instance_with_existing_network_interface],,[ignore],[ignore])
+AT_CLEANUP
+
+AT_SETUP([destroy run_instance_with_existing_network_interface])
+AT_CHECK([make -C "$SRCDIR" destroy-run_instance_with_existing_network_interface],,[ignore],[ignore])
+AT_CLEANUP
+
 AT_SETUP([apply run_instance_default_subnet])
 AT_CHECK([make -C "$SRCDIR" apply-run_instance_default_subnet],,[ignore],[ignore])
 AT_CLEANUP

--- a/tests/aws_instance.at
+++ b/tests/aws_instance.at
@@ -44,3 +44,11 @@ AT_CLEANUP
 AT_SETUP([destroy run_instance_with_ebs_override])
 AT_CHECK([make -C "$SRCDIR" destroy-run_instance_with_ebs_override],,[ignore],[ignore])
 AT_CLEANUP
+
+AT_SETUP([apply run_instance_default_subnet])
+AT_CHECK([make -C "$SRCDIR" apply-run_instance_default_subnet],,[ignore],[ignore])
+AT_CLEANUP
+
+AT_SETUP([destroy run_instance_default_subnet])
+AT_CHECK([make -C "$SRCDIR" destroy-run_instance_default_subnet],,[ignore],[ignore])
+AT_CLEANUP


### PR DESCRIPTION
**What this PR does / why we need it**:
  Due to INIS and default subnets support:
  * add example for run instance with existing network interface
  * add example for run instance in default subnet
  * add example for run instance with provided private IP
**Which issue(s) this PR fixes**:
  * #5 
**Special notes for your reviewer**:
