### PR TITLE
aws_vpc: implement import test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ dependencies="
       make: ........................ > 3.x.x
       sed: ......................... > 4.x.x
       terraform: ................... > 0.12.x
+      jq: .......................... > 1.x
       findutils: ................... > 4.x.x
       coreutils: ................... > 8.x.x
 
@@ -43,6 +44,12 @@ fi
 find_version=$(find --version | head -n 1 | awk '{print $4}')
 xargs_version=$(xargs --version | head -n 1 | awk '{print $4}')
 
+AC_CHECK_PROG(JQ,jq,jq)
+if test x$JQ = "x" ; then
+  AC_MSG_ERROR("${dependencies}jq is required to run examples.")
+fi
+jq_version=$(jq --version | awk -F- '{print $2}')
+
 
 AC_MSG_RESULT([
 ------------------------------------------------------------------------
@@ -52,6 +59,7 @@ AC_MSG_RESULT([
 
       Make version: .................. ${make_version}
       Terraform version: ............. ${terraform_version}
+      JQ version: ...................  ${jq_version}
       Find version: .................. ${find_version}
       Xargs version: ................. ${xargs_version}
 

--- a/tests/aws_vpc.at
+++ b/tests/aws_vpc.at
@@ -13,10 +13,12 @@ AT_SKIP_IF([test ! -d "$SRCDIR"cases/data_aws_vpc])
 AT_CHECK([make -C "$SRCDIR" apply-data_aws_vpc],,[ignore],[ignore])
 AT_CLEANUP
 
+AT_SETUP([import aws_vpc])
+AT_CHECK([make -C "$SRCDIR" import-aws_vpc],,[ignore],[ignore])
+AT_CLEANUP
+
 AT_SETUP([destroy aws_vpc])
 AT_CHECK([make -C "$SRCDIR" destroy-aws_vpc],,[ignore],[ignore])
 AT_CLEANUP
 
-AT_SETUP([import aws_vpc])
-AT_SKIP_IF([true])
-AT_CLEANUP
+


### PR DESCRIPTION
**What this PR does / why we need it**:
implement import test for aws_vpc resource

**Which issue(s) this PR fixes**:
#13 
**Special notes for your reviewer**:
```sh

import-$(lastword $(subst /, ,$(1))): 
	mv $(1)terraform.tfstate $(1)terraform.tfstate.main ;\
	$(TERRAFORM) import \
	-no-color \
	-state $(1)terraform.tfstate \
	-config $(1) \
	$(shell jq -r '.resources[] | "\(.type).\(.name) \(.instances[].attributes.id)"' $(1)terraform.tfstate 2>/dev/null) || exit 1 ;\
	rm $(1)terraform.tfstate ;\
	mv $(1)terraform.tfstate.main $(1)terraform.tfstate ;
```

so new target perform next things:
- at first ```$(shell ...)``` gnumake function use jq utility to get necessary data from .tfstate file in case dir
- we backup terraform.tfstate file, because terraform can import resource with existing .tfstate file
- run main terraform import command: 
- - -no-color - no color code (good for autotest checks)
- - -state - path to newly created .tfstate file (after successful import)
- - config - path to cases dir (./cases/aws_vpc) with main.tf file
- - $(shell ...) at this time there will be actual resourse string (for example aws_vpc.test_vpc vpc-xxxxx)
- - || exit 1 - if error occurred, stop target invocation with non zero error code
- remove newly created .tfstate file ( file which was created by terraform import command )
- restore backuped file