### PR TITLE
aws_ebs_volume: remove iops from example

### DIFF
--- a/cases/aws_ebs_volume/README.rst
+++ b/cases/aws_ebs_volume/README.rst
@@ -17,7 +17,7 @@ Unsupported attributes
 Notes
 ~~~~~
 
-``gp2`` and ``st2`` are valid values for ``type`` attribute.  ``iops = "400"`` is the only possible iops specification for disks with ``st2`` volume type. Disks with ``st2`` volume type must have ``size`` attribute value more then ``32G`` and be multiple of 8GiB. The volume size for ``gp2`` volume type varies from 8 GiB to 4 TiB. The volume size must be multiple of 8 GiB. For more information visit documentation `page <https://docs.cloud.croc.ru/en/services/instances_and_volumes/volumes.html>`_.
+``gp2`` and ``st2`` are valid values for ``type`` attribute. Disks with ``st2`` volume type must have ``size`` attribute value more then ``32G`` and be multiple of 8GiB. The volume size for ``gp2`` volume type varies from 8 GiB to 4 TiB. The volume size must be multiple of 8 GiB. For more information visit documentation `page <https://docs.cloud.croc.ru/en/services/instances_and_volumes/volumes.html>`_.
 
 Special notes
 -------------

--- a/cases/aws_ebs_volume/main.tf
+++ b/cases/aws_ebs_volume/main.tf
@@ -5,14 +5,12 @@ variable "types" {
 resource "aws_ebs_volume" "test_volume_iops" {
   # NOTE: 'encrypted', 'kms_key_id' attributes are not supported.
   #       'gp2' and 'st2' are valid values for 'type' attribute.
-  #       'iops = "400"' is only possible iops specification
-  #       for disks with 'st2' volume type. Disks with 'st2'
-  #       volume type must have size attribute value more then '32G'.
+  #       Disks with 'st2' volume type must have size attribute 
+  #       value more then '32G'.
   count = length(var.types)
 
   availability_zone = var.az
 
   size = 32
   type = var.types[count.index]
-  iops = "400"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/terraform-providers/terraform-provider-aws/blob/v2.70.0/aws/resource_aws_ebs_volume.go#L117 - iops volume parameter is only valid for ```io1``` volume type.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
